### PR TITLE
fix: androidX bug

### DIFF
--- a/example_app/.gitignore
+++ b/example_app/.gitignore
@@ -42,3 +42,5 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+!android/gradle.properties

--- a/example_app/android/gradle.properties
+++ b/example_app/android/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
fixes androidX bug

The Example App project was not setup for AndroidX. 
This PR adds the gradle.properties configuration to enable it. 