### PR TITLE
fix: release action

### DIFF
--- a/.github/workflows/release_flutter.yaml
+++ b/.github/workflows/release_flutter.yaml
@@ -44,28 +44,26 @@ jobs:
         run: |
           flutter pub publish -f
 
-      - name: Git version
-        id: version
-        uses: codacy/git-version@2.7.1
-        with:
-          release-branch: "main"
-
-      - name: Create a new tag
+      - name: Check a new tag
+        id: tag
         run: |
-          git tag ${{ steps.version.outputs.version }}
-          git push origin ${{ steps.version.outputs.version }}
-
+          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
+          echo $TAG_VERSION
+          git tag $TAG_VERSION
+          git push origin $TAG_VERSION
+      
       - name: Create a Release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{steps.version.outputs.version }}
+          tag: ${{steps.tag.outputs.version }}
           
   docs:
     runs-on: ubuntu-latest
     needs: [ release ]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.1.1
+      - name: 'Checkout'
+        uses: actions/checkout@v3
 
       - name: Guide
         uses: readmeio/rdme@8.3.0

--- a/.github/workflows/release_flutter.yaml
+++ b/.github/workflows/release_flutter.yaml
@@ -12,13 +12,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish:
+  release:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     environment: Production
+    outputs:
+      tag: ${{ steps.version.outputs.version }}
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: 'main'
 
       - name: 'Setup Dart'
         uses: dart-lang/setup-dart@v1
@@ -41,7 +46,7 @@ jobs:
 
       - name: Git version
         id: version
-        uses: codacy/git-version@2.4.0
+        uses: codacy/git-version@2.7.1
         with:
           release-branch: "main"
 

--- a/.github/workflows/release_flutter.yaml
+++ b/.github/workflows/release_flutter.yaml
@@ -62,7 +62,7 @@ jobs:
           
   docs:
     runs-on: ubuntu-latest
-    needs: [ publish ]
+    needs: [ release ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.1.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,6 +50,5 @@ jobs:
       - name: Create a new tag
         run: |
           export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
-          echo "TAG_VERSION=$PUBSPEC_VERSION"
           git tag $TAG_VERSION
       

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,18 +53,18 @@ jobs:
       #   with:
       #     release-branch: "main"
 
-      - name: Get pubsbec.yaml Version
-        id: pubspec_version
+      - name: Get Versions
+        id: get_versions
         run: |
           export PUBSPEC_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
           echo "PUBSPEC_VERSION=$PUBSPEC_VERSION"
           echo "{PUBSPEC_VERSION}={$PUBSPEC_VERSION}" >> $GITHUB_OUTPUT
-          export TAG_VERSION=$({{ steps.version.outputs.version }} | awk -F '-' '/1/ {print $1}')
+          export TAG_VERSION=$(echo ${{ steps.version.outputs.version }} | awk -F '-' '/1/ {print $1}')
           echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_OUTPUT
           echo "{TAG_VERSION}={$TAG_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check Release version
-        if:  ${{ steps.pubspec_version.outputs.TAG_VERSION }} != ${{ steps.pubspec_version.outputs.PUBSPEC_VERSION }}
+        if:  ${{ steps.get_versions.outputs.TAG_VERSION }} != ${{ steps.get_versions.outputs.PUBSPEC_VERSION }}
         uses: actions/github-script@v3
         with:
           script: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
           export PUBSPEC_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
           echo "PUBSPEC_VERSION=$PUBSPEC_VERSION"
           echo "{PUBSPEC_VERSION}={$PUBSPEC_VERSION}" >> $GITHUB_OUTPUT
-          export TAG_VERSION=$(${{ steps.version.outputs.version }} | awk -F '-' '/1/ {print $1}')
+          export TAG_VERSION=$({{ steps.version.outputs.version }} | awk -F '-' '/1/ {print $1}')
           echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_OUTPUT
           echo "{TAG_VERSION}={$TAG_VERSION}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,11 +47,11 @@ jobs:
       #   run: |
       #     flutter pub publish --dry-run
       
-      # - name: Git version
-      #   id: version
-      #   uses: codacy/git-version@2.7.1
-      #   with:
-      #     release-branch: "main"
+      - name: Git version
+        id: version
+        uses: codacy/git-version@2.7.1
+        with:
+          release-branch: "main"
 
       - name: Get Versions
         id: get_versions

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,5 +50,6 @@ jobs:
       - name: Create a new tag
         run: |
           export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          echo $TAG_VERSION
           git tag $TAG_VERSION
       

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,8 +13,11 @@ jobs:
   test:
     runs-on: macos-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: 'main'
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v1
@@ -43,3 +46,24 @@ jobs:
       - name: 'Test Publish SDK'
         run: |
           flutter pub publish --dry-run
+      
+      - name: Git version
+        id: version
+        uses: codacy/git-version@2.7.1
+        with:
+          release-branch: "main"
+
+      - name: Get pubsbec.yaml Version
+        id: pubspec_version
+        run: |
+          export PUBSPEC_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          echo "{PUBSPEC_VERSION}={$PUBSPEC_VERSION}" >> $GITHUB_OUTPUT
+          export TAG_VERSION=$(${{ steps.version.outputs.version }} | awk -F '-' '/1/ {print $1}')
+
+      - name: Check Release version
+        if:  ${{ steps.pubspec_version.outputs.TAG_VERSION }} != ${{ steps.pubspec_version.outputs.PUBSPEC_VERSION }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('git-version and pubspec version are different!')
+      

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,37 +19,36 @@ jobs:
           fetch-depth: 0
           ref: 'main'
 
-      # - name: Setup Flutter
-      #   uses: subosito/flutter-action@v1
-      #   with:
-      #     flutter-version: '3.3.4'
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v1
+        with:
+          flutter-version: '3.3.4'
 
-      # - name: Start iOS Simulator
-      #   run: |
-      #     xcrun xctrace list devices
-      #     UDID=$(xcrun xctrace list devices | grep "^iPhone 14 Simulator (16.2) (" | awk '{gsub(/[()]/,""); print $NF}')
-      #     echo $UDID
-      #     xcrun simctl boot "${UDID:?No Simulator with this name found}"
+      - name: Start iOS Simulator
+        run: |
+          xcrun xctrace list devices
+          UDID=$(xcrun xctrace list devices | grep "^iPhone 14 Simulator (16.2) (" | awk '{gsub(/[()]/,""); print $NF}')
+          echo $UDID
+          xcrun simctl boot "${UDID:?No Simulator with this name found}"
       
-      # - name: Load TIKI Credentials    
-      #   env:
-      #     TIKI_CREDENTIALS: ${{ secrets.TIKI_CREDENTIALS }}
-      #   run: |
-      #     echo "$TIKI_CREDENTIALS" >> integration_test/tiki_credentials.dart
+      - name: Load TIKI Credentials    
+        env:
+          TIKI_CREDENTIALS: ${{ secrets.TIKI_CREDENTIALS }}
+        run: |
+          echo "$TIKI_CREDENTIALS" >> integration_test/tiki_credentials.dart
 
-      # - name: Run iOS Integration Tests
-      #   run: flutter test integration_test/tiki_sdk_flutter_test.dart
+      - name: Run iOS Integration Tests
+        run: flutter test integration_test/tiki_sdk_flutter_test.dart
 
-      # - name: Run iOS TikiSdkPlatform Integration Tests
-      #   run: flutter test integration_test/tiki_sdk_flutter_platform_test.dart
+      - name: Run iOS TikiSdkPlatform Integration Tests
+        run: flutter test integration_test/tiki_sdk_flutter_platform_test.dart
 
-      # - name: 'Test Publish SDK'
-      #   run: |
-      #     flutter pub publish --dry-run
+      - name: 'Test Publish SDK'
+        run: |
+          flutter pub publish --dry-run
 
-      - name: Create a new tag
+      - name: Prints version
         run: |
           export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
           echo $TAG_VERSION
-          git tag $TAG_VERSION
       

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
           export PUBSPEC_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
           echo "PUBSPEC_VERSION=$PUBSPEC_VERSION"
           echo "{PUBSPEC_VERSION}={$PUBSPEC_VERSION}" >> $GITHUB_OUTPUT
-          export TAG_VERSION=$(echo ${{ steps.version.outputs.version }} | awk -F '-' '/1/ {print $1}')
+          export TAG_VERSION=$(echo {{ steps.version.outputs.version }} | awk -F '-' '/1/ {print $1}')
           echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_OUTPUT
           echo "{TAG_VERSION}={$TAG_VERSION}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,55 +19,31 @@ jobs:
           fetch-depth: 0
           ref: 'main'
 
-      # - name: Setup Flutter
-      #   uses: subosito/flutter-action@v1
-      #   with:
-      #     flutter-version: '3.3.4'
-
-      # - name: Start iOS Simulator
-      #   run: |
-      #     xcrun xctrace list devices
-      #     UDID=$(xcrun xctrace list devices | grep "^iPhone 14 Simulator (16.2) (" | awk '{gsub(/[()]/,""); print $NF}')
-      #     echo $UDID
-      #     xcrun simctl boot "${UDID:?No Simulator with this name found}"
-      
-      # - name: Load TIKI Credentials    
-      #   env:
-      #     TIKI_CREDENTIALS: ${{ secrets.TIKI_CREDENTIALS }}
-      #   run: |
-      #     echo "$TIKI_CREDENTIALS" >> integration_test/tiki_credentials.dart
-
-      # - name: Run iOS Integration Tests
-      #   run: flutter test integration_test/tiki_sdk_flutter_test.dart
-
-      # - name: Run iOS TikiSdkPlatform Integration Tests
-      #   run: flutter test integration_test/tiki_sdk_flutter_platform_test.dart
-
-      # - name: 'Test Publish SDK'
-      #   run: |
-      #     flutter pub publish --dry-run
-      
-      - name: Git version
-        id: version
-        uses: codacy/git-version@2.8.0
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v1
         with:
-          release-branch: "main"
+          flutter-version: '3.3.4'
 
-      - name: Get Versions
-        id: get_versions
+      - name: Start iOS Simulator
         run: |
-          export PUBSPEC_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
-          echo "PUBSPEC_VERSION=$PUBSPEC_VERSION"
-          echo "{PUBSPEC_VERSION}={$PUBSPEC_VERSION}" >> $GITHUB_OUTPUT
-          export GIT_VERSION_OUTPUT=${{ steps.version.outputs.version }}
-          export TAG_VERSION=$(echo $GIT_VERSION_OUTPUT | awk -F '-' '/1/ {print $1}')
-          echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_OUTPUT
-          echo "{TAG_VERSION}={$TAG_VERSION}" >> $GITHUB_OUTPUT
+          xcrun xctrace list devices
+          UDID=$(xcrun xctrace list devices | grep "^iPhone 14 Simulator (16.2) (" | awk '{gsub(/[()]/,""); print $NF}')
+          echo $UDID
+          xcrun simctl boot "${UDID:?No Simulator with this name found}"
+      
+      - name: Load TIKI Credentials    
+        env:
+          TIKI_CREDENTIALS: ${{ secrets.TIKI_CREDENTIALS }}
+        run: |
+          echo "$TIKI_CREDENTIALS" >> integration_test/tiki_credentials.dart
 
-      - name: Check Release version
-        if:  ${{ steps.get_versions.outputs.TAG_VERSION }} != ${{ steps.get_versions.outputs.PUBSPEC_VERSION }}
-        uses: actions/github-script@v3
-        with:
-          script: |
-            core.setFailed('git-version and pubspec version are different!')
+      - name: Run iOS Integration Tests
+        run: flutter test integration_test/tiki_sdk_flutter_test.dart
+
+      - name: Run iOS TikiSdkPlatform Integration Tests
+        run: flutter test integration_test/tiki_sdk_flutter_platform_test.dart
+
+      - name: 'Test Publish SDK'
+        run: |
+          flutter pub publish --dry-run
       

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,46 +19,49 @@ jobs:
           fetch-depth: 0
           ref: 'main'
 
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v1
-        with:
-          flutter-version: '3.3.4'
+      # - name: Setup Flutter
+      #   uses: subosito/flutter-action@v1
+      #   with:
+      #     flutter-version: '3.3.4'
 
-      - name: Start iOS Simulator
-        run: |
-          xcrun xctrace list devices
-          UDID=$(xcrun xctrace list devices | grep "^iPhone 14 Simulator (16.2) (" | awk '{gsub(/[()]/,""); print $NF}')
-          echo $UDID
-          xcrun simctl boot "${UDID:?No Simulator with this name found}"
+      # - name: Start iOS Simulator
+      #   run: |
+      #     xcrun xctrace list devices
+      #     UDID=$(xcrun xctrace list devices | grep "^iPhone 14 Simulator (16.2) (" | awk '{gsub(/[()]/,""); print $NF}')
+      #     echo $UDID
+      #     xcrun simctl boot "${UDID:?No Simulator with this name found}"
       
-      - name: Load TIKI Credentials    
-        env:
-          TIKI_CREDENTIALS: ${{ secrets.TIKI_CREDENTIALS }}
-        run: |
-          echo "$TIKI_CREDENTIALS" >> integration_test/tiki_credentials.dart
+      # - name: Load TIKI Credentials    
+      #   env:
+      #     TIKI_CREDENTIALS: ${{ secrets.TIKI_CREDENTIALS }}
+      #   run: |
+      #     echo "$TIKI_CREDENTIALS" >> integration_test/tiki_credentials.dart
 
-      - name: Run iOS Integration Tests
-        run: flutter test integration_test/tiki_sdk_flutter_test.dart
+      # - name: Run iOS Integration Tests
+      #   run: flutter test integration_test/tiki_sdk_flutter_test.dart
 
-      - name: Run iOS TikiSdkPlatform Integration Tests
-        run: flutter test integration_test/tiki_sdk_flutter_platform_test.dart
+      # - name: Run iOS TikiSdkPlatform Integration Tests
+      #   run: flutter test integration_test/tiki_sdk_flutter_platform_test.dart
 
-      - name: 'Test Publish SDK'
-        run: |
-          flutter pub publish --dry-run
+      # - name: 'Test Publish SDK'
+      #   run: |
+      #     flutter pub publish --dry-run
       
-      - name: Git version
-        id: version
-        uses: codacy/git-version@2.7.1
-        with:
-          release-branch: "main"
+      # - name: Git version
+      #   id: version
+      #   uses: codacy/git-version@2.7.1
+      #   with:
+      #     release-branch: "main"
 
       - name: Get pubsbec.yaml Version
         id: pubspec_version
         run: |
           export PUBSPEC_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          echo "PUBSPEC_VERSION=$PUBSPEC_VERSION"
           echo "{PUBSPEC_VERSION}={$PUBSPEC_VERSION}" >> $GITHUB_OUTPUT
           export TAG_VERSION=$(${{ steps.version.outputs.version }} | awk -F '-' '/1/ {print $1}')
+          echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_OUTPUT
+          echo "{TAG_VERSION}={$TAG_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check Release version
         if:  ${{ steps.pubspec_version.outputs.TAG_VERSION }} != ${{ steps.pubspec_version.outputs.PUBSPEC_VERSION }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
       
       - name: Git version
         id: version
-        uses: codacy/git-version@2.7.1
+        uses: codacy/git-version@2.8.0
         with:
           release-branch: "main"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,31 +19,37 @@ jobs:
           fetch-depth: 0
           ref: 'main'
 
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v1
-        with:
-          flutter-version: '3.3.4'
+      # - name: Setup Flutter
+      #   uses: subosito/flutter-action@v1
+      #   with:
+      #     flutter-version: '3.3.4'
 
-      - name: Start iOS Simulator
-        run: |
-          xcrun xctrace list devices
-          UDID=$(xcrun xctrace list devices | grep "^iPhone 14 Simulator (16.2) (" | awk '{gsub(/[()]/,""); print $NF}')
-          echo $UDID
-          xcrun simctl boot "${UDID:?No Simulator with this name found}"
+      # - name: Start iOS Simulator
+      #   run: |
+      #     xcrun xctrace list devices
+      #     UDID=$(xcrun xctrace list devices | grep "^iPhone 14 Simulator (16.2) (" | awk '{gsub(/[()]/,""); print $NF}')
+      #     echo $UDID
+      #     xcrun simctl boot "${UDID:?No Simulator with this name found}"
       
-      - name: Load TIKI Credentials    
-        env:
-          TIKI_CREDENTIALS: ${{ secrets.TIKI_CREDENTIALS }}
+      # - name: Load TIKI Credentials    
+      #   env:
+      #     TIKI_CREDENTIALS: ${{ secrets.TIKI_CREDENTIALS }}
+      #   run: |
+      #     echo "$TIKI_CREDENTIALS" >> integration_test/tiki_credentials.dart
+
+      # - name: Run iOS Integration Tests
+      #   run: flutter test integration_test/tiki_sdk_flutter_test.dart
+
+      # - name: Run iOS TikiSdkPlatform Integration Tests
+      #   run: flutter test integration_test/tiki_sdk_flutter_platform_test.dart
+
+      # - name: 'Test Publish SDK'
+      #   run: |
+      #     flutter pub publish --dry-run
+
+      - name: Create a new tag
         run: |
-          echo "$TIKI_CREDENTIALS" >> integration_test/tiki_credentials.dart
-
-      - name: Run iOS Integration Tests
-        run: flutter test integration_test/tiki_sdk_flutter_test.dart
-
-      - name: Run iOS TikiSdkPlatform Integration Tests
-        run: flutter test integration_test/tiki_sdk_flutter_platform_test.dart
-
-      - name: 'Test Publish SDK'
-        run: |
-          flutter pub publish --dry-run
+          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          echo "TAG_VERSION=$PUBSPEC_VERSION"
+          git tag $TAG_VERSION
       

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,8 @@ jobs:
           export PUBSPEC_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
           echo "PUBSPEC_VERSION=$PUBSPEC_VERSION"
           echo "{PUBSPEC_VERSION}={$PUBSPEC_VERSION}" >> $GITHUB_OUTPUT
-          export TAG_VERSION=$(echo {{ steps.version.outputs.version }} | awk -F '-' '/1/ {print $1}')
+          export GIT_VERSION_OUTPUT=${{ steps.version.outputs.version }}
+          export TAG_VERSION=$(echo $GIT_VERSION_OUTPUT | awk -F '-' '/1/ {print $1}')
           echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_OUTPUT
           echo "{TAG_VERSION}={$TAG_VERSION}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Update git-version in release action.

This PR just changes the release action. 

The git-version github action was removed and replaced by the version in the pubspec.yaml file.

Merging this PR will trigger the release of 1.1.0, that was failing.

Changes:
        modified:   .github/workflows/release_flutter.yaml
        modified:   .github/workflows/tests.yaml

