### PR TITLE
Release/aar and frameworks release

### DIFF
--- a/.github/workflows/release_aar.yaml
+++ b/.github/workflows/release_aar.yaml
@@ -20,9 +20,11 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v2
 
-      - name: Get Version From Tag
+      - name: Get Version From Pubspec
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: |
+          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          echo "tag=$TAG_VERSION" >> $GITHUB_OUTPUT
 
       - name: 'Setup Dart'
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/release_aar.yaml
+++ b/.github/workflows/release_aar.yaml
@@ -1,12 +1,19 @@
 name: Publish AARs
 
 on:
-  push:
-    tags:
-      - '*.*.*'
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
   publish:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     environment: Production
     steps:

--- a/.github/workflows/release_flutter.yaml
+++ b/.github/workflows/release_flutter.yaml
@@ -40,10 +40,6 @@ jobs:
           mkdir $XDG_CONFIG_HOME/dart
           echo '${{ secrets.PUB_DEV_CREDENTIALS }}' > "$XDG_CONFIG_HOME/dart/pub-credentials.json"
 
-      - name: 'Publish SDK'
-        run: |
-          flutter pub publish -f
-
       - name: Check a new tag
         id: tag
         run: |
@@ -57,6 +53,10 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{steps.tag.outputs.version }}
+
+      - name: 'Publish SDK'
+        run: |
+          flutter pub publish -f
           
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_xcframeworks.yaml
+++ b/.github/workflows/release_xcframeworks.yaml
@@ -1,12 +1,19 @@
 name: Publish XCFrameworks
 
 on:
-  push:
-    tags:
-      - '*.*.*'
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
   publish:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     runs-on: macos-latest
     environment: Production
     steps:


### PR DESCRIPTION
* Flutter pub publish moved o the end of the workflow
* Triggers for aar and frameworks changed o release/ PR closed
* Get version from pubspec.yaml, not tag (since tag is the pubspec.yaml version)

The original trigger was the tag push, but since the tag is created in
the github action, it will not trigger other action.

Changes
	modified:   .github/workflows/release_aar.yaml
	modified:   .github/workflows/release_flutter.yaml
	modified:   .github/workflows/release_xcframeworks.yaml