### PR TITLE
fix: remove tiki_sdk_flutter path from release

### DIFF
--- a/.github/workflows/release_xcframeworks.yaml
+++ b/.github/workflows/release_xcframeworks.yaml
@@ -43,27 +43,24 @@ jobs:
 
       - name: 'Remove Integration Test Dependency'
         run: |
-          cd tiki-sdk-flutter
           perl -i -p0e 's/  integration_test:\n    sdk: flutter//s' pubspec.yaml
 
       - name: 'Flutter pub get'
         run: |
-          cd tiki-sdk-flutter/
           flutter pub get
 
       - name: 'Add embed script in Xcode Project Build phases'
         run: |
-          cd tiki-sdk-flutter/.ios
+          cd .ios
           perl -i -p0e 's/shellScript = "\/bin\/sh \\"\$FLUTTER_ROOT\/packages\/flutter_tools\/bin\/xcode_backend\.sh\\" build";/shellScript = "\/bin\/sh \\"\$FLUTTER_ROOT\/packages\/flutter_tools\/bin\/xcode_backend\.sh\\" build\\n\/bin\/sh \\"\$FLUTTER_ROOT\/packages\/flutter_tools\/bin\/xcode_backend\.sh\\" embed\\n";/s' ./Runner.xcodeproj/project.pbxproj
 
       - name: "Build Frameworks"
         run: |
-          cd tiki-sdk-flutter
           flutter build ios-framework --output=Frameworks --no-profile
 
       - name: "Zip release frameworks"
         run: |
-          cd tiki-sdk-flutter/Frameworks/Release
+          cd Frameworks/Release
           zip -r sqlite3.xcframework.zip sqlite3.xcframework
           shasum -a 256 sqlite3.xcframework.zip | cut -f1 -d' '>> sqlite3.xcframework.checksum.txt
           zip -r flutter_secure_storage.xcframework.zip flutter_secure_storage.xcframework
@@ -81,7 +78,7 @@ jobs:
 
       - name: "Zip debug frameworks"
         run: |
-          cd tiki-sdk-flutter/Frameworks/Debug
+          cd Frameworks/Debug
           zip -r sqlite3_debug.xcframework.zip sqlite3.xcframework
           shasum -a 256 sqlite3_debug.xcframework.zip | cut -f1 -d' '>> sqlite3.xcframework_debug.checksum.txt
           zip -r flutter_secure_storage_debug.xcframework.zip flutter_secure_storage.xcframework
@@ -100,7 +97,7 @@ jobs:
       - name: Publish
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "tiki-sdk-flutter/Frameworks/Release/*.zip,tiki-sdk-flutter/Frameworks/Release/*.checksum.txt,tiki-sdk-flutter/Frameworks/Debug/*.zip,tiki-sdk-flutter/Frameworks/Debug/*.checksum.txt"
+          artifacts: "Frameworks/Release/*.zip,Frameworks/Release/*.checksum.txt,Frameworks/Debug/*.zip,Frameworks/Debug/*.checksum.txt"
           replacesArtifacts: false
           allowUpdates: true
           tag: ${{steps.tag.outputs.version }}


### PR DESCRIPTION
The Release workflow was loading the repository into the tiki_sdk_flutter directory. It changed in #184 but the commands were still trying to use the path. This PR removes the path from all the commands, to enable the Release.

Changes:
  modified:   .github/workflows/release_xcframeworks.yaml