### PR TITLE
fix: release action should checkout latest tag

### DIFF
--- a/.github/workflows/release_aar.yaml
+++ b/.github/workflows/release_aar.yaml
@@ -26,6 +26,9 @@ jobs:
           export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
           echo "tag=$TAG_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Checkout current tag
+        run: git checkout ${{steps.tag.outputs.version }}
+
       - name: 'Setup Dart'
         uses: dart-lang/setup-dart@v1
         with:

--- a/.github/workflows/release_flutter.yaml
+++ b/.github/workflows/release_flutter.yaml
@@ -21,9 +21,6 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: 'main'
 
       - name: 'Setup Dart'
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/release_xcframeworks.yaml
+++ b/.github/workflows/release_xcframeworks.yaml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - closed
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -25,6 +23,9 @@ jobs:
         run: |
           export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
           echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Checkout current tag
+        run: git checkout ${{steps.tag.outputs.version }}
 
       - name: "Setup Dart"
         uses: dart-lang/setup-dart@v1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tiki_sdk_flutter
 description: A package for adding TIKI's decentralized infrastructure to Flutter projects. Add tokenized data ownership, consent, and rewards to your app in minutes.
-version: 1.1.0
+version: 1.1.1
 homepage: https://mytiki.com
 documentation: https://docs.mytiki.com
 repository: https://github.com/tiki/tiki-sdk-flutter


### PR DESCRIPTION
With the change of the release workflow to the PR, it runs the GH action in the main branch before the code is merged. It needs to check out the new tag, not the main branch. Because of that, the release creates the artifacts in the main branch before the code is merged. 

Changes:
	modified:   .github/workflows/release_aar.yaml
	modified:   .github/workflows/release_flutter.yaml
	modified:   .github/workflows/release_xcframeworks.yaml
	modified:   pubspec.yaml