### PR TITLE
fix: update release action

### DIFF
--- a/.github/workflows/release_aar.yaml
+++ b/.github/workflows/release_aar.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: "Checkout TIKI SDK Flutter"
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Get Version From Pubspec
         id: tag

--- a/.github/workflows/release_aar.yaml
+++ b/.github/workflows/release_aar.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Get Version From Pubspec
         id: tag
         run: |
-          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '{print $2}')
           echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout current tag

--- a/.github/workflows/release_xcframeworks.yaml
+++ b/.github/workflows/release_xcframeworks.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: "Checkout TIKI SDK Flutter"
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Get Version From Pubspec
         id: tag

--- a/.github/workflows/release_xcframeworks.yaml
+++ b/.github/workflows/release_xcframeworks.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Get Version From Pubspec
         id: tag
         run: |
-          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '{print $2}')
           echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout current tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1
+
+* fix Dart formatting
+* fix release binaries action - checkout tags
+
 ## 2.0.0
 
 * BREAKING CHANGE: upgrade to TIKI SDK Dart 2.0

--- a/lib/src/tiki_platform_channel/req/req_guard.dart
+++ b/lib/src/tiki_platform_channel/req/req_guard.dart
@@ -18,8 +18,11 @@ class ReqGuard {
     ptr = map["ptr"];
     destinations =
         map["destinations"]?.map<String>((e) => e.toString()).toList() ?? [];
-    uses = map["usecases"].map<LicenseUsecase>((e) =>
-        LicenseUsecase.from(e["usecaseEnum"].toString())).toList() ?? [];
+    uses = map["usecases"]
+            .map<LicenseUsecase>(
+                (e) => LicenseUsecase.from(e["usecaseEnum"].toString()))
+            .toList() ??
+        [];
     origin = map["origin"];
   }
 }

--- a/lib/src/tiki_platform_channel/req/req_license.dart
+++ b/lib/src/tiki_platform_channel/req/req_license.dart
@@ -35,11 +35,18 @@ class ReqLicense {
       Map<String, List<String>> usesMap = {
         "destinations":
             destinationsList?.map<String>((e) => e.toString()).toList() ?? [],
-        "usecases": usesList?.map<String>((e) => e["usecaseEnum"].toString()).toList() ?? []};
+        "usecases": usesList
+                ?.map<String>((e) => e["usecaseEnum"].toString())
+                .toList() ??
+            []
+      };
       uses.add(LicenseUse.fromMap(usesMap));
     }
 
-    for (String tag in map["tags"]?.map<String>((e) => e["titleTagEnum"].toString()).toList() ?? []) {
+    for (String tag in map["tags"]
+            ?.map<String>((e) => e["titleTagEnum"].toString())
+            .toList() ??
+        []) {
       tags.add(TitleTag.from(tag));
     }
   }

--- a/lib/src/tiki_platform_channel/req/req_title.dart
+++ b/lib/src/tiki_platform_channel/req/req_title.dart
@@ -19,7 +19,8 @@ class ReqTitle {
     origin = map["origin"];
     description = map["description"];
 
-    for (String tag in map["tags"].map<String>((e) => e.toString()).toList() ?? []) {
+    for (String tag
+        in map["tags"].map<String>((e) => e.toString()).toList() ?? []) {
       tags.add(TitleTag.from(tag));
     }
   }

--- a/lib/src/tiki_platform_channel/rsp/rsp_license.dart
+++ b/lib/src/tiki_platform_channel/rsp/rsp_license.dart
@@ -21,17 +21,20 @@ class RspLicense extends Rsp {
     Map licenseMap = {
       "id": license.id,
       "title": {
-        "id" : license.title.id,
+        "id": license.title.id,
         "ptr": license.title.ptr,
         "description": license.title.description,
         "tags": license.title.tags
-            .map<Map<String,String>>((titleTag)  => {"titleTagEnum": titleTag.value})
+            .map<Map<String, String>>(
+                (titleTag) => {"titleTagEnum": titleTag.value})
             .toList(),
         "origin": license.title.origin
       },
       "uses": license.uses
           .map<Map<String, List>>((LicenseUse use) => {
-                "usecases": use.usecases.map<Map<String,String>>((LicenseUsecase usecase) => {"usecaseEnum": usecase.value})
+                "usecases": use.usecases
+                    .map<Map<String, String>>((LicenseUsecase usecase) =>
+                        {"usecaseEnum": usecase.value})
                     .toList(),
                 "destinations": use.destinations ?? []
               })

--- a/lib/src/tiki_platform_channel/rsp/rsp_license_list.dart
+++ b/lib/src/tiki_platform_channel/rsp/rsp_license_list.dart
@@ -22,34 +22,32 @@ class RspLicenseList extends Rsp {
     if (licenseList.isEmpty) return [];
     List<Map> returnList = [];
     for (LicenseRecord license in licenseList) {
-        Map licenseMap = {
-          "id": license.id,
-          "title": {
-            "id": license.title.id,
-            "ptr": license.title.ptr,
-            "description": license.title.description,
-            "tags": license.title.tags
-                .map<Map<String, String>>((titleTag) =>
-            {
-              "titleTagEnum": titleTag.value
-            })
-                .toList(),
-            "origin": license.title.origin
-          },
-          "uses": license.uses
-              .map<Map<String, List>>((LicenseUse use) =>
-          {
-            "usecases": use.usecases.map<Map<String, String>>((
-                LicenseUsecase usecase) => {"usecaseEnum": usecase.value})
-                .toList(),
-            "destinations": use.destinations ?? []
-          })
+      Map licenseMap = {
+        "id": license.id,
+        "title": {
+          "id": license.title.id,
+          "ptr": license.title.ptr,
+          "description": license.title.description,
+          "tags": license.title.tags
+              .map<Map<String, String>>(
+                  (titleTag) => {"titleTagEnum": titleTag.value})
               .toList(),
-          "terms": license.terms,
-          "description": license.description,
-          "expiry": license.expiry?.millisecondsSinceEpoch
-        };
-        returnList.add(licenseMap);
+          "origin": license.title.origin
+        },
+        "uses": license.uses
+            .map<Map<String, List>>((LicenseUse use) => {
+                  "usecases": use.usecases
+                      .map<Map<String, String>>((LicenseUsecase usecase) =>
+                          {"usecaseEnum": usecase.value})
+                      .toList(),
+                  "destinations": use.destinations ?? []
+                })
+            .toList(),
+        "terms": license.terms,
+        "description": license.description,
+        "expiry": license.expiry?.millisecondsSinceEpoch
+      };
+      returnList.add(licenseMap);
     }
     return returnList;
   }

--- a/lib/src/tiki_platform_channel/rsp/rsp_title.dart
+++ b/lib/src/tiki_platform_channel/rsp/rsp_title.dart
@@ -19,10 +19,8 @@ class RspTitle extends Rsp {
     Map titleMap = {
       "ptr": title.ptr,
       "description": title.description,
-      "tags": title.tags.map<Map<String, String>>((titleTag) =>
-      {
-        "titleTagEnum": titleTag.value
-      }),
+      "tags": title.tags.map<Map<String, String>>(
+          (titleTag) => {"titleTagEnum": titleTag.value}),
       "origin": title.origin
     };
     return jsonEncode(titleMap);

--- a/lib/ui/markdown.dart
+++ b/lib/ui/markdown.dart
@@ -29,5 +29,5 @@ class MarkdownViewer extends StatelessWidget {
       data: mdText,
       styleSheet: MarkdownStyleSheet.fromTheme(ThemeData(
           textTheme: TextTheme(
-              bodyText2: TextStyle(fontSize: 20.0, color: textColor)))));
+              bodyMedium: TextStyle(fontSize: 20.0, color: textColor)))));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tiki_sdk_flutter
 description: A package for adding TIKI's decentralized infrastructure to Flutter projects. Add tokenized data ownership, consent, and rewards to your app in minutes.
-version: 2.0.0
+version: 2.0.1
 homepage: https://mytiki.com
 documentation: https://docs.mytiki.com/docs
 repository: https://github.com/tiki/tiki-sdk-flutter


### PR DESCRIPTION
Update the release action checkout job to fetch all tags. Without it, the release action cannot checkout the latest tag to release.

Fix tag regex and Dart format for lib folder.
