### PR TITLE
fix: incorrect spelling in app permission

### DIFF
--- a/lib/src/widgets/offer_prompt.dart
+++ b/lib/src/widgets/offer_prompt.dart
@@ -142,8 +142,11 @@ class OfferPrompt extends StatelessWidget {
 
   String _permissionsNames() {
     if (permissions.length == 1) {
-      String snakeName = permissions.first.toString().split(".")[1];
-      return snakeName.split("_").join(" ").toLowerCase();
+      String snakeName = permissions.first.toString().split(("."))[1];
+      return snakeName.replaceAllMapped(
+          RegExp(r'([A-Z])'),
+              (match) => ' ${match.group(0)}'
+      ).toLowerCase();
     }
     return "permissions";
   }


### PR DESCRIPTION
fix #267 

## Changes Made

Added a regex expression which converts the `camelCase` permission object into lowercase spaced string.